### PR TITLE
Respect BROWSER env var when starting webpack dev server.

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -125,7 +125,7 @@ function startBrowserProcess(browser, url, args) {
   // Fallback to open
   // (It will always open new tab)
   try {
-    var options = { app: browser, wait: false, url: true };
+    var options = { app: { name: browser }, wait: false, url: true };
     open(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {


### PR DESCRIPTION
The `browser` option is ignored (on Mac OS X), as it is not provided correctly in the options to `open`. This attempts to fix that.

Note: I only have a mac, so I've tested this on Mac OS X. I suppose it needs to be tested cross-platform. On Mac, this change allows me to choose the browser through the `BROWSER` env var.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
